### PR TITLE
Convert API json data to dataclasses

### DIFF
--- a/stonfi/http/api_client.py
+++ b/stonfi/http/api_client.py
@@ -1,78 +1,105 @@
 import aiohttp
 from pytoniq import Address
 
+from stonfi.types import Asset, AssetsResponse, FarmsResponse, Farm, Pool, PoolsResponse, SwapSimulate, SwapStatus
+
+
 class HTTPAPI:
     def __init__(self,
                  base_url: str = 'https://api.ston.fi/'):
         self.base_url = base_url.rstrip('/')
-    
+
     async def get(self, path: str, **kwargs):
         async with aiohttp.ClientSession() as session:
             async with session.get(self.base_url + path, params=kwargs) as resp:
                 result = await resp.json()
         return result
-    
-    async def post(self, path: str, **kwargs):
+
+    async def post(self, path: str, params):
+        params = {key: val for key, val in params.items() if val is not None}
         async with aiohttp.ClientSession() as session:
-            async with session.post(self.base_url + path, json=kwargs) as resp:
+            async with session.post(self.base_url + path, params=params) as resp:
                 result = await resp.json()
         return result
-    
-    async def get_assets(self):
-        return await self.get('/v1/assets')
-    
-    async def get_farms(self):
-        return await self.get('/v1/farms')
-    
-    async def get_markets(self):
-        return await self.get('/v1/markets')
-    
-    async def get_pools(self):
-        return await self.get('/v1/pools')
-    
-    async def simulate_swap(self,
+
+    async def get_assets(self) -> list[Asset]:
+        return AssetsResponse.from_dict(await self.get('/v1/assets')).asset_list
+
+    async def get_farms(self) -> list[Farm]:
+        return FarmsResponse.from_dict(await self.get('/v1/farms')).farm_list
+
+    async def get_markets(self) -> list:
+        response = await self.get('/v1/markets')
+        return response['pairs']
+
+    async def get_pools(self) -> list[Pool]:
+        return PoolsResponse.from_dict(await self.get('/v1/pools')).pool_list
+
+    async def swap_simulate(self,
                             offer_address: str | Address,
                             ask_address: str | Address,
                             units: int | str,
                             slippage_tolerance: float = 0.01,
-                            referral_address: str | Address | None = None):
-        return await self.post('/v1/swap/simulate',
-                               offer_address=offer_address.to_str() if isinstance(offer_address, Address) else offer_address,
-                               ask_address=ask_address.to_str() if isinstance(ask_address, Address) else ask_address,
-                               units=str(units),
-                               slippage_tolerance=str(round(slippage_tolerance * 100, 3)),
-                               referral_address=referral_address.to_str() if isinstance(referral_address, Address) else referral_address)
-    
+                            referral_address: str | Address | None = None) -> SwapSimulate:
+        params = {
+            "offer_address": offer_address.to_str() if isinstance(offer_address, Address) else offer_address,
+            "ask_address": ask_address.to_str() if isinstance(ask_address, Address) else ask_address,
+            "units": str(units),
+            "slippage_tolerance": str(round(slippage_tolerance * 100, 3)),
+            "referral_address": referral_address.to_str() if isinstance(referral_address, Address) else referral_address
+        }
+        return SwapSimulate.from_dict(await self.post('/v1/swap/simulate', params))
+
+    async def reverse_swap_simulate(self,
+                                    offer_address: str | Address,
+                                    ask_address: str | Address,
+                                    units: int | str,
+                                    slippage_tolerance: float = 0.01,
+                                    referral_address: str | Address | None = None) -> SwapSimulate:
+        params = {
+            "offer_address": offer_address.to_str() if isinstance(offer_address, Address) else offer_address,
+            "ask_address": ask_address.to_str() if isinstance(ask_address, Address) else ask_address,
+            "units": str(units),
+            "slippage_tolerance": str(round(slippage_tolerance * 100, 3)),
+            "referral_address": referral_address.to_str() if isinstance(referral_address, Address) else referral_address
+        }
+        return SwapSimulate.from_dict(await self.post('/v1/reverse_swap/simulate', params))
+
     async def get_swap_status(self,
                               router_address: str | Address,
                               owner_address: str | Address,
-                              query_id: int | str):
-        return await self.get(f'/v1/swap/status',
-                               router_address=router_address.to_str() if isinstance(router_address, Address) else router_address,
-                               owner_address=owner_address.to_str() if isinstance(owner_address, Address) else owner_address,
-                               query_id=str(query_id))
-    
+                              query_id: int | str) -> SwapStatus:
+        return SwapStatus.from_dict(
+            await self.get(f'/v1/swap/status',
+                           router_address=router_address.to_str() if isinstance(router_address,
+                                                                                Address) else router_address,
+                           owner_address=owner_address.to_str() if isinstance(owner_address,
+                                                                              Address) else owner_address,
+                           query_id=str(query_id)))
+
     async def get_jetton_wallet_address(self,
                                         owner_address: str | Address,
-                                        addr_str: str | Address):
-        return await self.get(f'/v1/jetton/{addr_str.to_str() if isinstance(addr_str, Address) else addr_str}/address',
-                               owner_address=owner_address.to_str() if isinstance(owner_address, Address) else owner_address)
-    
+                                        addr_str: str | Address) -> Address:
+        result = await self.get(
+            f'/v1/jetton/{addr_str.to_str() if isinstance(addr_str, Address) else addr_str}/address',
+            owner_address=owner_address.to_str() if isinstance(owner_address, Address) else owner_address)
+        return Address(result['address'])
+
     async def get_wallet_assets(self,
-                                addr_str: str | Address):
-        return await self.get(f'/v1/wallets/{addr_str.to_str() if isinstance(addr_str, Address) else addr_str}/assets')
-    
+                                addr_str: str | Address) -> list[Asset]:
+        return AssetsResponse.from_dict(
+            await self.get(f'/v1/wallets/{addr_str.to_str()if isinstance(addr_str, Address) else addr_str}/assets')
+        ).asset_list
+
     async def get_wallet_farms(self,
-                                addr_str: str | Address):
-        return await self.get(f'/v1/wallets/{addr_str.to_str() if isinstance(addr_str, Address) else addr_str}/farms')
-    
+                               addr_str: str | Address) -> list[Farm]:
+        return FarmsResponse.from_dict(
+            await self.get(f'/v1/wallets/{addr_str.to_str() if isinstance(addr_str, Address) else addr_str}/farms')
+        ).farm_list
+
     # TODO: /v1/wallets/{addr_str}/operations
     # TODO: /v1/wallets/{addr_str}/pools
     # TODO: /v1/stats/dex
     # TODO: /v1/stats/operations
     # TODO: /v1/stats/pool
     # TODO: /export/cmc/v1
-    
-    async def close(self):
-        await self.session.close()
-

--- a/stonfi/types/__init__.py
+++ b/stonfi/types/__init__.py
@@ -1,0 +1,3 @@
+from stonfi.types.http import (
+    FarmsResponse, Farm, AssetsResponse, Asset, Pool, PoolsResponse, SwapSimulate, SwapStatus
+)

--- a/stonfi/types/http/__init__.py
+++ b/stonfi/types/http/__init__.py
@@ -1,0 +1,4 @@
+from stonfi.types.http.assets import AssetsResponse, Asset
+from stonfi.types.http.farms import Farm, FarmsResponse
+from stonfi.types.http.pools import Pool, PoolsResponse
+from stonfi.types.http.swap import SwapSimulate, SwapStatus

--- a/stonfi/types/http/assets.py
+++ b/stonfi/types/http/assets.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+from dataclasses_json import CatchAll, Undefined, dataclass_json
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class Asset:
+    blacklisted: bool
+    community: bool
+    decimals: int
+    default_symbol: bool
+    deprecated: bool
+    display_name: str
+    image_url: str
+    kind: str
+    symbol: str
+    contract_address: str
+    dex_price_usd: str | None = None
+    third_party_price_usd: str | None = None
+    third_party_usd_price: str | None = None
+    dex_usd_price: str | None = None
+    balance: str | None = None
+    wallet_address: str | None = None
+    unknown_things: CatchAll = None
+
+    @classmethod
+    def from_dict(cls, param):
+        pass
+
+    @classmethod
+    def schema(cls):
+        pass
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class AssetsResponse:
+    asset_list: list[Asset]
+    unknown_things: CatchAll = None
+
+    @classmethod
+    def from_dict(cls, param):
+        pass

--- a/stonfi/types/http/farms.py
+++ b/stonfi/types/http/farms.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+from dataclasses_json import CatchAll, Undefined, dataclass_json
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class NftInfo:
+    unknown_things: CatchAll = None
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class Farm:
+    apy: str
+    min_stake_duration_s: str
+    minter_address: str
+    nft_infos: list[NftInfo]
+    pool_address: str
+    reward_token_address: str
+    status: str
+    unknown_things: CatchAll = None
+
+    @classmethod
+    def schema(cls):
+        pass
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class FarmsResponse:
+    farm_list: list[Farm]
+    unknown_things: CatchAll = None
+
+    @classmethod
+    def from_dict(cls, param):
+        pass

--- a/stonfi/types/http/pools.py
+++ b/stonfi/types/http/pools.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+from dataclasses_json import CatchAll, Undefined, dataclass_json
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class Pool:
+    address: str
+    collected_token0_protocol_fee: str
+    collected_token1_protocol_fee: str
+    deprecated: bool
+    lp_fee: str
+    lp_price_usd: str
+    lp_total_supply: str
+    lp_total_supply_usd: str
+    protocol_fee: str
+    protocol_fee_address: str
+    ref_fee: str
+    reserve0: str
+    reserve1: str
+    router_address: str
+    token0_address: str
+    token1_address: str
+    apy_7d: str | None = None
+    apy_30d: str | None = None
+    apy_1d: str | None = None
+    unknown_things: CatchAll = None
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class PoolsResponse:
+    pool_list: list[Pool]
+    unknown_things: CatchAll = None
+
+    @classmethod
+    def from_dict(cls, param):
+        pass

--- a/stonfi/types/http/swap.py
+++ b/stonfi/types/http/swap.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+
+from dataclasses_json import CatchAll, Undefined, dataclass_json
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class SwapSimulate:
+    ask_address: str
+    ask_units: str
+    fee_address: str
+    fee_percent: str
+    fee_units: str
+    min_ask_units: str
+    offer_address: str
+    offer_units: str
+    pool_address: str
+    price_impact: str
+    router_address: str
+    slippage_tolerance: str
+    swap_rate: str
+    unknown_things: CatchAll = None
+
+    @classmethod
+    def from_dict(cls, param):
+        pass
+
+
+# @dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class SwapStatus:
+    type: str
+    address: str | None = None
+    balance_deltas: str | None = None
+    coins: str | None = None
+    exit_code: str | None = None
+    logical_time: str | None = None
+    query_id: str | None = None
+    tx_hash: str | None = None
+
+    # unknown_things: CatchAll = None
+
+    @staticmethod
+    def from_dict(obj: dict) -> 'SwapStatus':
+        _type = obj.get('@type')
+        _address = obj.get("address")
+        _balance_deltas = obj.get("balance_deltas")
+        _coins = obj.get("coins")
+        _exit_code = obj.get("exit_code")
+        _logical_time = obj.get("logical_time")
+        _query_id = obj.get("query_id")
+        _tx_hash = obj.get("tx_hash")
+        return SwapStatus(_type, _address, _balance_deltas, _coins, _exit_code, _logical_time, _query_id, _tx_hash)

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -2,12 +2,102 @@ import pytest
 import asyncio
 from stonfi.http import HTTPAPI
 
+http_api = HTTPAPI()
+
+
 @pytest.mark.asyncio
-async def test_http_api():
-    http_api = HTTPAPI()
+async def test_get_assets():
     assets = await http_api.get_assets()
     assert assets is not None
     assert len(assets) > 0
-    print('First asset: ', assets['asset_list'][0])
-    await http_api.close()
+    print('First asset: ', assets[0].display_name)
 
+
+@pytest.mark.asyncio
+async def test_get_farms():
+    farms = await http_api.get_farms()
+    assert farms is not None
+    assert len(farms) > 0
+    print('First farm pool address: ', farms[0].pool_address)
+
+
+@pytest.mark.asyncio
+async def test_get_markets():
+    markets = await http_api.get_markets()
+    assert markets is not None
+    assert len(markets) > 0
+    print('First pair: ', markets[0])
+
+
+@pytest.mark.asyncio
+async def test_get_pools():
+    pools = await http_api.get_pools()
+    assert pools is not None
+    assert len(pools) > 0
+    print('First pool address: ', pools[0].address)
+
+
+@pytest.mark.asyncio
+async def test_swap_simulate():
+    swap_simulate = await http_api.swap_simulate(
+        offer_address='EQBynBO23ywHy_CgarY9NK9FTz0yDsG82PtcbSTQgGoXwiuA',
+        ask_address='EQCM3B12QK1e4yZSf8GtBRT0aLMNyEsBc_DhVfRRtOEffLez',
+        units='300',
+        slippage_tolerance=0.01,
+    )
+    print('Swap rate: ', swap_simulate.swap_rate)
+
+
+@pytest.mark.asyncio
+async def test_reverse_swap_simulate():
+    simulate = await http_api.reverse_swap_simulate(
+        offer_address='EQBynBO23ywHy_CgarY9NK9FTz0yDsG82PtcbSTQgGoXwiuA',
+        ask_address='EQCM3B12QK1e4yZSf8GtBRT0aLMNyEsBc_DhVfRRtOEffLez',
+        units='300',
+        slippage_tolerance=0.01,
+    )
+    print('Reverse Swap rate: ', simulate.swap_rate)
+
+
+@pytest.mark.asyncio
+async def test_get_swap_status():
+    status = await http_api.get_swap_status(
+        router_address='EQB3ncyBUTjZUA5EnFKR5_EnOMI9V1tTEAAPaiU71gc4TiUt',
+        owner_address='EQCM3B12QK1e4yZSf8GtBRT0aLMNyEsBc_DhVfRRtOEffLez',
+        query_id=1,
+    )
+    print('Status: ', status.type)
+
+
+@pytest.mark.asyncio
+async def test_jetton_wallet_address():
+    address = await http_api.get_jetton_wallet_address(
+        'EQB3ncyBUTjZUA5EnFKR5_EnOMI9V1tTEAAPaiU71gc4TiUt',
+        'EQB5Wjo7yXdaB70yBoN2YEv8iVPjAdMObf_Dq40ELLaPllNb'
+    )
+    print('Address: ', address.to_str(is_user_friendly=True))
+
+
+@pytest.mark.asyncio
+async def test_get_jetton_wallet_address():
+    address = await http_api.get_jetton_wallet_address(
+        'EQB3ncyBUTjZUA5EnFKR5_EnOMI9V1tTEAAPaiU71gc4TiUt',
+        'EQB5Wjo7yXdaB70yBoN2YEv8iVPjAdMObf_Dq40ELLaPllNb'
+    )
+    print('Jetton address: ', address.to_str(is_user_friendly=True))
+
+
+@pytest.mark.asyncio
+async def test_get_wallet_assets():
+    assets = await http_api.get_wallet_assets("EQB3ncyBUTjZUA5EnFKR5_EnOMI9V1tTEAAPaiU71gc4TiUt")
+    assert assets is not None
+    assert len(assets) > 0
+    print('First asset balance: ', int(assets[0].balance) / 1e9, assets[0].display_name)
+
+
+@pytest.mark.asyncio
+async def test_get_wallet_farms():
+    farm = await http_api.get_wallet_farms("EQB3ncyBUTjZUA5EnFKR5_EnOMI9V1tTEAAPaiU71gc4TiUt")
+    assert farm is not None
+    assert len(farm) > 0
+    print('First farm pool address: ', farm[0].pool_address)


### PR DESCRIPTION
Add "assets", "farms", "pools", "swap" dataclasses

now easy to use API data

```python
assets = await http_api.get_wallet_assets("EQB3ncyBUTjZUA5EnFKR5_EnOMI9V1tTEAAPaiU71gc4TiUt")
first_asset = assets[0]

print('Asset balance: ', int(first_asset.balance) / 1e9, first_asset.display_name)
print('Contract address: ', first_asset.contract_address)

"""
Asset balance:  1823.826116114 TON
Contract address:  EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c
"""
```

Also:
- fix swap_simulate method
- add reverse_swap method
- add API tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new data classes for handling assets, farms, pools, and swaps, enhancing data serialization and deserialization.
  - Added new API methods for fetching assets, farms, markets, pools, and wallet information, as well as simulating and checking swap statuses.

- **Bug Fixes**
  - Improved parameter handling in API methods for better accuracy and performance.

- **Tests**
  - Added comprehensive test functions for new API endpoints to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->